### PR TITLE
Add config support (via autoconfig1u), improved code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 A server side mod to enable command history, auto completion and syntax
 highlighting on the server console. Should have zero impact on the gameplay.
 
-Fabric is the only supported mod loader, fabric api is not required by this
-mod.
+Fabric is the only supported mod loader, fabric api is not required by this mod.
 
-This mod currently doesn't have anything configurable. Any suggestions would
-be appreciated.
+This mod is configurable using `jline4mcdsrv.toml`:
+* `logPattern` is the pattern used for Log4J (documentation [here](https://logging.apache.org/log4j/2.x/manual/layouts.html#Patterns))
+*  `highlightColors` is a list of colors used to highlight parameters in order
+   (see image above for an example)
 
 This is my first mod for Minecraft. Actually this is also the first time for me
 to do anything serious using Java. So please be gentle if you want to roast my

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -12,6 +12,8 @@ group = project.maven_group
 
 repositories {
 	maven { url "https://repo1.maven.org/maven2/" }
+	maven { url "https://maven.fabricmc.net/" }
+	jcenter()
 }
 
 configurations {
@@ -32,7 +34,9 @@ dependencies {
 	provided "org.jline:jline-terminal-jansi:3.15.0"
 	provided "org.fusesource.jansi:jansi:1.18"
 
-	modImplementation("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}")
+	modApi("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
+		exclude module: 'fabric-api'
+	}
 	include "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	provided "org.fusesource.jansi:jansi:1.18"
 
 	modApi("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
-		exclude module: 'fabric-api'
+		exclude(group: "net.fabricmc.fabric-api")
 	}
 	include "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	provided "org.jline:jline:3.15.0"
 	provided "org.jline:jline-terminal-jansi:3.15.0"
 	provided "org.fusesource.jansi:jansi:1.18"
+
+	modImplementation("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}")
+	include "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,11 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.10.5+build.213
 
 # Mod Properties
-	mod_version = 0.0.3
+	mod_version = 0.1.0
 	maven_group = org.chrisoft
 	archives_base_name = jline4mcdsrv
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.5.1+build.294-1.15
+	auto_config_version=3.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on ~~https://fabricmc.net/use~~ https://modmuss50.me/fabric.html
-	minecraft_version=1.16.3
-	yarn_mappings=1.16.3+build.47
-	loader_version=0.10.5+build.213
+	minecraft_version=1.16.5
+	yarn_mappings=1.16.5+build.3
+	loader_version=0.11.1
 
 # Mod Properties
 	mod_version = 0.1.0
@@ -14,5 +14,5 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.5.1+build.294-1.15
+	fabric_version=0.29.4+1.16
 	auto_config_version=3.3.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Jun 07 00:17:23 CST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
@@ -11,7 +11,6 @@ import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.UserInterruptException;
-import java.io.Serializable;
 
 public class Console
 {
@@ -48,7 +47,7 @@ public class Console
                 };
                 conAppender.start();
 
-                //replace SysOut appender with conAppender
+                // replace SysOut appender with conAppender
                 LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
                 LoggerConfig conf = ctx.getConfiguration().getLoggerConfig(logger.getName());
                 conf.removeAppender("SysOut");

--- a/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
@@ -22,20 +22,6 @@ public class Console
             public void run()
             {
                 Logger logger = (Logger) LogManager.getLogger();
-                String pattern = null;
-
-                //try to get appender pattern in Log4j2 configuration
-                //e.g. <Queue name="JLine"><PatternLayout pattern="..." /></Queue>
-                Appender jLineAppender = logger.getAppenders().get("JLine");
-                if (jLineAppender != null) {
-                    Layout<? extends Serializable> layout = jLineAppender.getLayout();
-                    if (layout != null)
-                        pattern = layout.getContentFormat().get("format");
-                }
-
-                //else use mod configuration
-                if (pattern == null)
-                    pattern = JLineForMcDSrvMain.config.logPattern;
 
                 LineReader lr = LineReaderBuilder.builder()
                     .completer(new MinecraftCommandCompleter(srv.getCommandManager().getDispatcher(), srv.getCommandSource()))
@@ -44,7 +30,7 @@ public class Console
                     .build();
 
                 Appender conAppender = new AbstractAppender("Console", null,
-                    PatternLayout.newBuilder().withPattern(pattern).build(), false)
+                    PatternLayout.newBuilder().withPattern(JLineForMcDSrvMain.config.logPattern).build(), false)
                 {
                     @Override
                     public void append(LogEvent event) {
@@ -65,7 +51,6 @@ public class Console
                 //replace SysOut appender with conAppender
                 LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
                 LoggerConfig conf = ctx.getConfiguration().getLoggerConfig(logger.getName());
-                conf.removeAppender("JLine"); //only used to set log pattern
                 conf.removeAppender("SysOut");
                 conf.addAppender(conAppender, conf.getLevel(), null);
                 ctx.updateLoggers();

--- a/src/main/java/org/chrisoft/jline4mcdsrv/JLineForMcDSrvConfig.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/JLineForMcDSrvConfig.java
@@ -1,0 +1,42 @@
+package org.chrisoft.jline4mcdsrv;
+
+import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
+import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
+
+import java.util.*;
+
+@Config(name = "jline4mcdsrv")
+public class JLineForMcDSrvConfig implements ConfigData
+{
+	//Represent AttributedStyle.BLACK = 0, AttributedStyle.RED = 1 etc
+	public static final List<String> colorList = Collections.unmodifiableList(new ArrayList<>(Arrays.asList(
+		"BLACK", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE")));
+
+	public String logPattern = "%style{[%d{HH:mm:ss}]}{blue} "
+		+ "%highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} "
+		+ "%style{(%logger{1})}{cyan} "
+		+ "%highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}";
+
+	public String[] highlightColors = {"CYAN", "YELLOW", "GREEN", "MAGENTA", "WHITE"};
+
+	@Override
+	public void validatePostLoad() throws ConfigData.ValidationException {
+		for (int i = 0; i < highlightColors.length; i++) {
+			highlightColors[i] = highlightColors[i].toUpperCase();
+
+			int styleColor = colorList.indexOf(highlightColors[i]);
+			if (styleColor == -1)
+				throw new ConfigData.ValidationException("highlightColors[" + i + "] needs to be one of " + colorList);
+		}
+	}
+
+	//for use in Highlighter
+	public int[] getHighlightColors() {
+		int[] styleColors = new int[highlightColors.length];
+		for (int i = 0; i < highlightColors.length; i++) {
+			int styleColor = colorList.indexOf(highlightColors[i]);
+			styleColors[i] = styleColor;
+		}
+		return styleColors;
+	}
+}

--- a/src/main/java/org/chrisoft/jline4mcdsrv/JLineForMcDSrvConfig.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/JLineForMcDSrvConfig.java
@@ -8,35 +8,29 @@ import java.util.*;
 @Config(name = "jline4mcdsrv")
 public class JLineForMcDSrvConfig implements ConfigData
 {
-	//Represent AttributedStyle.BLACK = 0, AttributedStyle.RED = 1 etc
-	public static final List<String> colorList = Collections.unmodifiableList(new ArrayList<>(Arrays.asList(
-		"BLACK", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE")));
+	// Represent AttributedStyle.BLACK = 0, AttributedStyle.RED = 1, ... AttributedStyle.WHITE = 7
+	private enum StyleColor {
+		BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE
+	}
 
 	public String logPattern = "%style{[%d{HH:mm:ss}]}{blue} "
 		+ "%highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} "
 		+ "%style{(%logger{1})}{cyan} "
 		+ "%highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}";
 
-	public String[] highlightColors = {"CYAN", "YELLOW", "GREEN", "MAGENTA", "WHITE"};
+	private StyleColor[] highlightColors = {StyleColor.CYAN, StyleColor.YELLOW, StyleColor.GREEN, StyleColor.MAGENTA, StyleColor.WHITE};
+
+	public transient int[] highlightColorIndices;
 
 	@Override
 	public void validatePostLoad() throws ConfigData.ValidationException {
+		// transform the color names into their AttributedStyle index
+		highlightColorIndices = new int[highlightColors.length];
 		for (int i = 0; i < highlightColors.length; i++) {
-			highlightColors[i] = highlightColors[i].toUpperCase();
+			if (highlightColors[i] == null)
+				throw new ConfigData.ValidationException("highlightColors[" + i + "] needs to be one of " + Arrays.toString(StyleColor.values()));
 
-			int styleColor = colorList.indexOf(highlightColors[i]);
-			if (styleColor == -1)
-				throw new ConfigData.ValidationException("highlightColors[" + i + "] needs to be one of " + colorList);
+			highlightColorIndices[i] = highlightColors[i].ordinal();
 		}
-	}
-
-	//for use in Highlighter
-	public int[] getHighlightColors() {
-		int[] styleColors = new int[highlightColors.length];
-		for (int i = 0; i < highlightColors.length; i++) {
-			int styleColor = colorList.indexOf(highlightColors[i]);
-			styleColors[i] = styleColor;
-		}
-		return styleColors;
 	}
 }

--- a/src/main/java/org/chrisoft/jline4mcdsrv/JLineForMcDSrvMain.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/JLineForMcDSrvMain.java
@@ -1,12 +1,20 @@
 package org.chrisoft.jline4mcdsrv;
 
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.sargunvohra.mcmods.autoconfig1u.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ModInitializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class JLineForMcDSrvMain implements ModInitializer
 {
+	public static JLineForMcDSrvConfig config;
+	public static final Logger LOGGER = LogManager.getLogger("jline4mcdsrv");
+
 	@Override
 	public void onInitialize()
 	{
-		//System.out.println("Hello Fabric world!");
+		AutoConfig.register(JLineForMcDSrvConfig.class, Toml4jConfigSerializer::new);
+		config = AutoConfig.getConfigHolder(JLineForMcDSrvConfig.class).getConfig();
 	}
 }

--- a/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandCompleter.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandCompleter.java
@@ -15,28 +15,26 @@ import java.util.concurrent.CompletableFuture;
 
 public class MinecraftCommandCompleter implements Completer
 {
+    private final CommandDispatcher<ServerCommandSource> cmdDispatcher;
+    private final ServerCommandSource cmdSrc;
 
-    private CommandDispatcher<ServerCommandSource> cmddispatcher;
-    private ServerCommandSource cmdsrc;
-    private ParseResults<ServerCommandSource> parseres;
-
-    public MinecraftCommandCompleter(CommandDispatcher<ServerCommandSource> _cmddispatcher, ServerCommandSource _cmdsrc)
+    public MinecraftCommandCompleter(CommandDispatcher<ServerCommandSource> cmdDispatcher, ServerCommandSource cmdSrc)
     {
-        cmddispatcher = _cmddispatcher;
-        cmdsrc = _cmdsrc;
+        this.cmdDispatcher = cmdDispatcher;
+        this.cmdSrc = cmdSrc;
     }
 
     @Override
     public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates)
     {
-        parseres = cmddispatcher.parse(line.line(), cmdsrc);
-        CompletableFuture<Suggestions> cs = cmddispatcher.getCompletionSuggestions(parseres, line.cursor());
+        ParseResults<ServerCommandSource> parseRes = cmdDispatcher.parse(line.line(), cmdSrc);
+        CompletableFuture<Suggestions> cs = cmdDispatcher.getCompletionSuggestions(parseRes, line.cursor());
         Suggestions sl = cs.join();
         for (Suggestion s : sl.getList()) {
             String applied = s.apply(line.line());
             ParsedLine apl = reader.getParser().parse(applied, line.cursor());
-            String candstr = apl.word();
-            candidates.add(new Candidate(candstr));
+            String candStr = apl.word();
+            candidates.add(new Candidate(candStr));
         }
     }
 }

--- a/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandHighlighter.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandHighlighter.java
@@ -22,7 +22,7 @@ public class MinecraftCommandHighlighter implements Highlighter
     {
         this.cmdDispatcher = cmdDispatcher;
         this.cmdSrc = cmdSrc;
-        colors = JLineForMcDSrvMain.config.getHighlightColors();
+        colors = JLineForMcDSrvMain.config.highlightColorIndices;
     }
 
     @Override

--- a/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandHighlighter.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandHighlighter.java
@@ -10,31 +10,29 @@ import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 
-import java.util.List;
 import java.util.regex.Pattern;
 
 public class MinecraftCommandHighlighter implements Highlighter
 {
-    private CommandDispatcher<ServerCommandSource> cmddispatcher;
-    private ServerCommandSource cmdsrc;
+    private final CommandDispatcher<ServerCommandSource> cmdDispatcher;
+    private final ServerCommandSource cmdSrc;
+    private final int[] colors;
 
-    public MinecraftCommandHighlighter(CommandDispatcher<ServerCommandSource> _cmddispatcher, ServerCommandSource _cmdsrc)
+    public MinecraftCommandHighlighter(CommandDispatcher<ServerCommandSource> cmdDispatcher, ServerCommandSource cmdSrc)
     {
-        cmddispatcher = _cmddispatcher;
-        cmdsrc = _cmdsrc;
+        this.cmdDispatcher = cmdDispatcher;
+        this.cmdSrc = cmdSrc;
+        colors = JLineForMcDSrvMain.config.getHighlightColors();
     }
 
     @Override
     public AttributedString highlight(LineReader reader, String buffer)
     {
-        final int[] colors = new int[]{AttributedStyle.CYAN, AttributedStyle.YELLOW, AttributedStyle.GREEN, AttributedStyle.MAGENTA, AttributedStyle.WHITE};
         AttributedStringBuilder sb = new AttributedStringBuilder();
-        ParseResults<ServerCommandSource> parse = cmddispatcher.parse(buffer, cmdsrc);
-        List nodes = parse.getContext().getNodes();
+        ParseResults<ServerCommandSource> parse = cmdDispatcher.parse(buffer, cmdSrc);
         int pos = 0;
         int component = -1;
-        for (Object _node : nodes) {
-            ParsedCommandNode<ServerCommandSource> pcn = (ParsedCommandNode)_node;
+        for (ParsedCommandNode<ServerCommandSource> pcn : parse.getContext().getNodes()) {
             if (++component >= colors.length)
                 component = 0;
             if (pcn.getRange().getStart() >= buffer.length())
@@ -45,9 +43,8 @@ public class MinecraftCommandHighlighter implements Highlighter
             sb.append(buffer.substring(start, end), AttributedStyle.DEFAULT.foreground(colors[component]));
             pos = end;
         }
-        if (pos < buffer.length()) {
+        if (pos < buffer.length())
             sb.append((buffer.substring(pos)), AttributedStyle.DEFAULT);
-        }
         return sb.toAttributedString();
     }
 

--- a/src/main/java/org/chrisoft/jline4mcdsrv/mixin/DServerConsoleThreadInject.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/mixin/DServerConsoleThreadInject.java
@@ -1,20 +1,18 @@
 package org.chrisoft.jline4mcdsrv.mixin;
 
+import org.chrisoft.jline4mcdsrv.JLineForMcDSrvMain;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.apache.logging.log4j.LogManager;
 
 @Mixin(targets = {"net.minecraft.server.dedicated.MinecraftDedicatedServer$1"})
-public class DServerConsoleThreadInject {
-    @Inject(
-            at = @At("HEAD"),
-            method = "run()V",
-            cancellable = true)
+public abstract class DServerConsoleThreadInject
+{
+    @Inject(at = @At("HEAD"), method = "run()V", cancellable = true)
     private void consoleThreadQuit(CallbackInfo info)
     {
-        LogManager.getLogger().info("Vanilla console thread stopped.");
+        JLineForMcDSrvMain.LOGGER.info("Vanilla console thread stopped.");
         info.cancel();
     }
 }

--- a/src/main/java/org/chrisoft/jline4mcdsrv/mixin/DServerInject.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/mixin/DServerInject.java
@@ -8,20 +8,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.chrisoft.jline4mcdsrv.Console;
 
 @Mixin(MinecraftDedicatedServer.class)
-public abstract class DServerInject {
-
-    private Console con;
-    private MinecraftDedicatedServer dsrv;
+public abstract class DServerInject
+{
+    private MinecraftDedicatedServer dSrv;
 
     @Inject(at = @At("HEAD"), method = "setupServer()Z")
-    private void preSetupServer(CallbackInfoReturnable<Boolean> info) {
-        dsrv = (MinecraftDedicatedServer) (Object) this;
+    private void preSetupServer(CallbackInfoReturnable<Boolean> info)
+    {
+        dSrv = (MinecraftDedicatedServer) (Object) this;
     }
 
     @Inject(at = @At("TAIL"), method = "setupServer()Z")
-    private void setupServer(CallbackInfoReturnable<Boolean> info) {
-        con = new Console(dsrv);
-        con.setup();
+    private void setupServer(CallbackInfoReturnable<Boolean> info)
+    {
+        Console.setup(dSrv);
     }
-
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "jline4mcdsrv",
-  "version": "0.0.3",
+  "version": "0.1.0",
 
   "name": "JLine for Minecraft Dedicated Server",
   "description": "Enables command history, auto completion and syntax highlighting on the server console.",


### PR DESCRIPTION
**EDIT** updated the description to reflect all changes.

- add TOML config
- configurable log pattern
- configurable highlight color*
- use own logger (and change thread name) so it doesn't appear to be Vanilla
- more consistent code style
- update versions of Loom, Minecraft, Yarn mappings and Fabric Loader

The default TOML file looks like this:
```
logPattern = "%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"
highlightColors = ["CYAN", "YELLOW", "GREEN", "MAGENTA", "WHITE"]
```

\* Highlight colors are a bit weird because setting them all red still leaves the suggestions cyan
![weird](https://user-images.githubusercontent.com/8464472/100398673-fec7f900-304f-11eb-92fd-43a1b0cf8195.png)
