### PR TITLE
Compatibility hack for Not Enough Crashes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.11.1
 
 # Mod Properties
-	mod_version = 0.1.0
+	mod_version = 0.1.1
 	maven_group = org.chrisoft
 	archives_base_name = jline4mcdsrv
 

--- a/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
@@ -2,15 +2,25 @@ package org.chrisoft.jline4mcdsrv;
 
 import net.minecraft.server.dedicated.MinecraftDedicatedServer;
 import net.minecraft.util.logging.UncaughtExceptionLogger;
-import org.apache.logging.log4j.core.*;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.rewrite.RewriteAppender;
+import org.apache.logging.log4j.core.appender.rewrite.RewritePolicy;
+import org.apache.logging.log4j.core.config.AppenderRef;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.jetbrains.annotations.Nullable;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.UserInterruptException;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.chrisoft.jline4mcdsrv.JLineForMcDSrvMain.LOGGER;
 
 public class Console
 {
@@ -20,36 +30,27 @@ public class Console
         {
             public void run()
             {
-                Logger logger = (Logger) LogManager.getLogger();
-
                 LineReader lr = LineReaderBuilder.builder()
                     .completer(new MinecraftCommandCompleter(srv.getCommandManager().getDispatcher(), srv.getCommandSource()))
                     .highlighter(new MinecraftCommandHighlighter(srv.getCommandManager().getDispatcher(), srv.getCommandSource()))
                     .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
                     .build();
 
-                Appender conAppender = new AbstractAppender("Console", null,
-                    PatternLayout.newBuilder().withPattern(JLineForMcDSrvMain.config.logPattern).build(), false)
-                {
-                    @Override
-                    public void append(LogEvent event) {
-                        if (lr.isReading())
-                            lr.callWidget(lr.CLEAR);
-
-                        lr.getTerminal().writer().print(getLayout().toSerializable(event).toString());
-
-                        if (lr.isReading()) {
-                            lr.callWidget(lr.REDRAW_LINE);
-                            lr.callWidget(lr.REDISPLAY);
-                        }
-                        lr.getTerminal().writer().flush();
-                    }
-                };
+                ConsoleAppender conAppender = new ConsoleAppender(lr);
                 conAppender.start();
 
-                // replace SysOut appender with conAppender
+                Logger logger = (Logger) LogManager.getLogger();
                 LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
                 LoggerConfig conf = ctx.getConfiguration().getLoggerConfig(logger.getName());
+
+                // compatibility hack for Not Enough Crashes
+                RewritePolicy policy = getNECRewritePolicy(conf);
+                if (policy != null) {
+                    conAppender.setRewritePolicy(policy);
+                    removeSysOutFromNECRewriteAppender(ctx, conf, policy);
+                }
+
+                // replace SysOut appender with Console appender
                 conf.removeAppender("SysOut");
                 conf.addAppender(conAppender, conf.getLevel(), null);
                 ctx.updateLoggers();
@@ -68,7 +69,52 @@ public class Console
             }
         };
         conThrd.setDaemon(true);
-        conThrd.setUncaughtExceptionHandler(new UncaughtExceptionLogger(JLineForMcDSrvMain.LOGGER));
+        conThrd.setUncaughtExceptionHandler(new UncaughtExceptionLogger(LOGGER));
         conThrd.start();
+    }
+
+    /** Read the RewritePolicy Not Enough Crashes uses to deobfuscate stack traces */
+    @Nullable
+    private static RewritePolicy getNECRewritePolicy(LoggerConfig conf) {
+        for (Appender appender : conf.getAppenders().values()) {
+            if (appender.getName().equals("NotEnoughCrashesDeobfuscatingAppender")) {
+                try {
+                    Field field = appender.getClass().getDeclaredField("rewritePolicy");
+                    field.setAccessible(true);
+                    return (RewritePolicy) field.get(appender);
+                } catch (Exception e) {
+                    LOGGER.error("Couldn't read Not Enough Crashes' rewritePolicy", e);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void removeSysOutFromNECRewriteAppender(LoggerContext ctx, LoggerConfig conf, RewritePolicy policy) {
+        /*
+         * This method is pretty hacky: we remove, recreate and readd NEC's appender
+         * For (MIT-licensed) reference see:
+         * https://github.com/natanfudge/Not-Enough-Crashes/blob/147495dd4097017f4d243ead7f7e20d0ccfb7d40/notenoughcrashes/src/main/java/fudge/notenoughcrashes/DeobfuscatingRewritePolicy.java#L17-L41
+         */
+
+        conf.removeAppender("NotEnoughCrashesDeobfuscatingAppender");
+
+        // get all AppenderRefs except SysOut
+        List<AppenderRef> appenderRefs = new ArrayList<>(conf.getAppenderRefs());
+        appenderRefs.removeIf((ref) -> ref.getRef().equals("SysOut"));
+
+        // wrap them in a RewriteAppender
+        RewriteAppender rewriteAppender = RewriteAppender.createAppender(
+            "NotEnoughCrashesDeobfuscatingAppender",
+            "true",
+            appenderRefs.toArray(new AppenderRef[0]),
+            ctx.getConfiguration(),
+            policy,
+            null
+        );
+        rewriteAppender.start();
+
+        conf.addAppender(rewriteAppender, null, null);
     }
 }

--- a/src/main/java/org/chrisoft/jline4mcdsrv/ConsoleAppender.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/ConsoleAppender.java
@@ -1,0 +1,40 @@
+package org.chrisoft.jline4mcdsrv;
+
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.rewrite.RewritePolicy;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.jline.reader.LineReader;
+
+public class ConsoleAppender extends AbstractAppender {
+
+    protected LineReader lr;
+    protected RewritePolicy policy;
+
+    public ConsoleAppender(LineReader lr) {
+        super("Console", null, PatternLayout.newBuilder().withPattern(JLineForMcDSrvMain.config.logPattern).build(), false);
+        this.lr = lr;
+    }
+
+    public void setRewritePolicy(RewritePolicy policy) {
+        this.policy = policy;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (policy != null)
+            event = policy.rewrite(event);
+
+        if (lr.isReading())
+            lr.callWidget(lr.CLEAR);
+
+        lr.getTerminal().writer().print(getLayout().toSerializable(event).toString());
+
+        if (lr.isReading()) {
+            lr.callWidget(lr.REDRAW_LINE);
+            lr.callWidget(lr.REDISPLAY);
+        }
+        lr.getTerminal().writer().flush();
+    }
+}


### PR DESCRIPTION
This fixes #5, meaning there will be no double log lines with NEC installed and NEC's stack trace deobfuscation will work too.

The methodology didn't change from https://github.com/chirs241097/jline4mcdsrv/issues/5#issuecomment-766859189.