### PR TITLE
fixed trailing white-space causing incorrect argument error

### DIFF
--- a/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
@@ -56,7 +56,9 @@ public class Console
 
                 while (!srv.isStopped() && srv.isRunning()) {
                     try {
-                        String s = lr.readLine("/");
+                        String s = lr.readLine("/").trim();
+                        if (s.equals(""))
+                            continue;
                         srv.enqueueCommand(s, srv.getCommandSource());
                         if (s.equals("stop"))
                             break;


### PR DESCRIPTION
A simple change that could trim the trailing white-space brought by auto-completion, and allow the console to ignore blank lines. 

The PR is mainly aimed to address this #3 issue.