### PR TITLE
Fix #3

### DIFF
--- a/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/Console.java
@@ -57,6 +57,9 @@ public class Console
                 while (!srv.isStopped() && srv.isRunning()) {
                     try {
                         String s = lr.readLine("/");
+                        if (s.isEmpty()) {
+                            continue;
+                        }
                         srv.enqueueCommand(s, srv.getCommandSource());
                         if (s.equals("stop"))
                             break;

--- a/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandCompleter.java
+++ b/src/main/java/org/chrisoft/jline4mcdsrv/MinecraftCommandCompleter.java
@@ -34,7 +34,7 @@ public class MinecraftCommandCompleter implements Completer
             String applied = s.apply(line.line());
             ParsedLine apl = reader.getParser().parse(applied, line.cursor());
             String candStr = apl.word();
-            candidates.add(new Candidate(candStr));
+            candidates.add(new Candidate(candStr, candStr, null, null, null, null, false));
         }
     }
 }


### PR DESCRIPTION
This is another attempt at fixing #3.

This is the default `Candidate` constructor used currently:
```java
public Candidate(String value) {
  this(value, value, null, null, null, null, true);
}
```
The last `true` is for the `complete` boolean, which the doc describes as follows:

>Boolean indicating whether this candidate is complete or if the completer may further expand the candidate value after this candidate has been selected. This can be the case when completing folders for example. If the candidate is complete and is selected, a space separator will be added.

By instead calling the all-args constructor and specifying false for `complete`, spaces will no longer be added to the end of tab completions (tested to be the case). Due to this I did not trim the input string, although trimming the input string could also be done.

Also no longer processes empty input as a command.